### PR TITLE
feat: Add HTTP request on Dial button release (closes #18)

### DIFF
--- a/.cursor/commands/solve_issue.md
+++ b/.cursor/commands/solve_issue.md
@@ -1,0 +1,20 @@
+# Check, analyze and solve the GitHub issue
+
+## About
+
+Check GitHub issue by running `gh issue view` command and analyze, solve the issue.
+
+## Steps
+
+1. ** Check GitHub issue by running `gh issue view` command**
+  - Read issue title, description. Understand the background.
+  - If there are any other issues linked, read them and udnerstand them too.
+
+2. ** Check current codebase according to the issue**
+  - Read codebase and understand why we have to solve the issue.
+  - Analyze way to solve the issue by reading files, codes.
+
+3. ** Solve the issue**
+  - Modify the code and solve the issue
+  - check if it is solved. Run compile check or unit tests if needed.
+  - If it was complicated issue, make a comment on the issue/PR for documentation.

--- a/Source/code/dial.go
+++ b/Source/code/dial.go
@@ -108,6 +108,43 @@ func (s *SDHTTP) DialDownHandler(ctx context.Context, client *streamdeck.Client,
 	return nil
 }
 
+// DialUpHandler Handles "DialUp" action
+func (s *SDHTTP) DialUpHandler(ctx context.Context, client *streamdeck.Client, event streamdeck.Event) error {
+	payload := streamdeck.DialUpPayload[DialPI]{}
+	if err := json.Unmarshal(event.Payload, &payload); err != nil {
+		msg := fmt.Sprintf("Failed to unmarshal DialUp event payload: %s", err)
+		client.LogMessage(ctx, msg)
+		client.ShowAlert(ctx)
+		return err
+	}
+
+	// If no URL is set, don't send request
+	if payload.Settings.URLRelease == "" {
+		return nil
+	}
+
+	r := request{
+		body:              payload.Settings.Body,
+		method:            payload.Settings.Method,
+		url:               payload.Settings.URLRelease,
+		showAlert:         payload.Settings.ShowAlert,
+		basicAuthID:       payload.Settings.BasicAuthID,
+		basicAuthPassword: payload.Settings.BasicAuthPassword,
+	}
+
+	if err := s.do(ctx, client, r); err != nil {
+		return err
+	}
+
+	msg := fmt.Sprintf("Request succeeded :%v", payload.Settings)
+	client.LogMessage(ctx, msg)
+
+	if payload.Settings.ShowOK {
+		client.ShowOk(ctx)
+	}
+	return nil
+}
+
 func (s *SDHTTP) TouchTapHandler(ctx context.Context, client *streamdeck.Client, event streamdeck.Event) error {
 	payload := streamdeck.TouchTapPayload[DialPI]{}
 	if err := json.Unmarshal(event.Payload, &payload); err != nil {

--- a/Source/code/pi.go
+++ b/Source/code/pi.go
@@ -48,10 +48,11 @@ func (p *KeyDownPI) Initialize() {
 
 type DialPI struct {
 	pi
-	URLLeft  string `json:"url_left"`
-	URLRight string `json:"url_right"`
-	URLPush  string `json:"url_push"`
-	URLTouch string `json:"url_touch"`
+	URLLeft    string `json:"url_left"`
+	URLRight   string `json:"url_right"`
+	URLPush    string `json:"url_push"`
+	URLRelease string `json:"url_release"`
+	URLTouch   string `json:"url_touch"`
 }
 
 // IsDefault Check if its default
@@ -65,6 +66,7 @@ func (p *DialPI) Initialize() {
 	p.URLLeft = "https://www.elgato.com"
 	p.URLRight = "https://www.elgato.com"
 	p.URLPush = "https://www.elgato.com"
+	p.URLRelease = ""
 	p.URLTouch = "https://www.elgato.com"
 	p.Body = ""
 	p.BasicAuthID = ""

--- a/Source/code/sd.go
+++ b/Source/code/sd.go
@@ -37,6 +37,7 @@ func NewSDHTTP(ctx context.Context, params streamdeck.RegistrationParams) *SDHTT
 	dialAction.RegisterHandler(streamdeck.WillDisappear, ret.DialWillDisapperHandler)
 	dialAction.RegisterHandler(streamdeck.DialRotate, ret.DialRotateHandler)
 	dialAction.RegisterHandler(streamdeck.DialDown, ret.DialDownHandler)
+	dialAction.RegisterHandler(streamdeck.DialUp, ret.DialUpHandler)
 	dialAction.RegisterHandler(streamdeck.TouchTap, ret.TouchTapHandler)
 
 	return ret

--- a/Source/pi/pi_dial.html
+++ b/Source/pi/pi_dial.html
@@ -47,6 +47,13 @@
     </div>
 
     <div class="sdpi-item">
+      <div class="sdpi-item-label">URL(release)</div>
+      <div class="sdpi-item-child">
+        <input id="url_release" class="sdProperty" onInput="setSettings()"></input>
+      </div>
+    </div>
+
+    <div class="sdpi-item">
       <div class="sdpi-item-label">URL(touch)</div>
       <div class="sdpi-item-child">
         <input id="url_touch" class="sdProperty" onInput="setSettings()"></input>


### PR DESCRIPTION
## 概要
DialのHTTPアクションに「ボタンを離した際にHTTPリクエストを発行」する機能を追加しました。

## 変更内容
- \DialPI\構造体に\URLRelease\フィールドを追加
- \DialUpHandler\関数を実装（ボタンを離した際のHTTPリクエスト処理）
- \sd.go\で\DialUp\イベントのハンドラを登録
- \DialPI.Initialize()\に\URLRelease\の初期化を追加

## 動作
通常のボタンアクション（\KeyUp\）と同様に、Dialのボタンを離した際に設定されたURLに対してHTTPリクエストが送信されます。

## テスト
- コンパイル成功を確認
- Lintエラーなし
- 既存機能への影響なし

Closes #18

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an HTTP request trigger when the Dial button is released, including a new `URLRelease` setting, handler, and UI field.
> 
> - **Dial action**:
>   - Implement `DialUpHandler` to send requests on dial release using `settings.url_release`.
>   - Register `streamdeck.DialUp` handler in `sd.go`.
> - **Settings/PI**:
>   - Extend `DialPI` with `URLRelease` and initialize it in `DialPI.Initialize()`.
>   - Update `pi_dial.html` to include input for `url_release`.
> - **Docs**:
>   - Add `.cursor/commands/solve_issue.md` helper instructions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b81a33d4ecc2aae95993085a9a6124ad261aa433. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->